### PR TITLE
ID for AI-Thinker ESP32-CAM board for use with Circuitpython

### DIFF
--- a/creations/espressif.md
+++ b/creations/espressif.md
@@ -3,6 +3,7 @@ Community Allocated Creation IDs for Espressif boards
 
 ## `0x0032_xxxx` - ESP32 dev boards
 *  `0x0032_0001` ESP-EYE
+*  `0x0032_0002` ESP32-CAM
 
 ## `0x0052_xxxx` - S2 dev boards
 


### PR DESCRIPTION
Add id for AI-Thinker ESP32-CAM board for use with Circuitpython