### PR TITLE
Add T-SIM7000G

### DIFF
--- a/creations/lilygo.md
+++ b/creations/lilygo.md
@@ -4,3 +4,4 @@ Community Allocated Creation IDs for LILYGO boards
 ## `0x00C3_xxxx` - ESP32-C3 boards
 *  `0x00C3_0001` [TTGO T-01C3](https://github.com/Xinyuan-LilyGO/T-01C3)
 *  `0x00C3_0002` [TTGO T-OI-PLUS](https://github.com/Xinyuan-LilyGO/LilyGo-T-OI-PLUS)
+*  `0x00C3_9102` [TTGO T-SIM7000G](https://github.com/Xinyuan-LilyGO/LilyGO-T-SIM7000G) [+](https://www.aliexpress.com/item/4000542688096.html)

--- a/creations/lilygo.md
+++ b/creations/lilygo.md
@@ -4,4 +4,5 @@ Community Allocated Creation IDs for LILYGO boards
 ## `0x00C3_xxxx` - ESP32-C3 boards
 *  `0x00C3_0001` [TTGO T-01C3](https://github.com/Xinyuan-LilyGO/T-01C3)
 *  `0x00C3_0002` [TTGO T-OI-PLUS](https://github.com/Xinyuan-LilyGO/LilyGo-T-OI-PLUS)
-*  `0x00C3_9102` [TTGO T-SIM7000G](https://github.com/Xinyuan-LilyGO/LilyGO-T-SIM7000G) [+](https://www.aliexpress.com/item/4000542688096.html)
+*  `0x00C3_0003` [TTGO T-SIM7000G](https://github.com/Xinyuan-LilyGO/LilyGO-T-SIM7000G)
+*  `0x00C3_0004` [TTGO T-PCIE](https://github.com/Xinyuan-LilyGO/LilyGo-T-PCIE)


### PR DESCRIPTION
Adding the Lilygo TTGO T-SIM7000G.
 Rather than take the next number in the LilyGo list for creation_id I've gone with the product variant code from the aliexpress official page of 9102. (I assume we should to follow the existing id prefix when picking the creation ID? If not then I would have stuck with my original commit of 0x00009102). Also what do the underscores mean in creation/creator IDs?

This commit relates to https://github.com/tyeth/circuitpython/tree/add-lilygo-ttgo-tsim7000g