### PR TITLE
Add creation id for ESP32-C3S

### DIFF
--- a/creations/ai-thinker.md
+++ b/creations/ai-thinker.md
@@ -3,11 +3,11 @@
 Community Allocated Creation IDs for AI Thinker boards
 
 ## `0x0032_xxxx` - ESP32 dev boards
-*  `0x0032_0001` ESP32-C3S-2M
-*  `0x0032_0002` ESP32-C3S  
 
 ## `0x0052_xxxx` - S2 dev boards
 
 ## `0x0053_xxxx` - S3 dev boards
 
 ## `0x00C3_xxxx` - C3 dev boards
+*  `0x00C3_0001` ESP32-C3S-2M
+*  `0x00C3_0002` ESP32-C3S  

--- a/creations/ai-thinker.md
+++ b/creations/ai-thinker.md
@@ -4,6 +4,7 @@ Community Allocated Creation IDs for AI Thinker boards
 
 ## `0x0032_xxxx` - ESP32 dev boards
 *  `0x0032_0001` ESP32-C3S-2M
+*  `0x0032_0002` ESP32-C3S  
 
 ## `0x0052_xxxx` - S2 dev boards
 


### PR DESCRIPTION
This board currently has these creator/creation IDs, which were chosen before 
```make
CIRCUITPY_CREATOR_ID = 0x70010001
CIRCUITPY_CREATION_ID = 0x00100001
```
Change to use one from the proper series. I'll make a corresponding PR in CircuitPython after this.

EDIT: Also fixed the other ESP32-C3 board to use one from the proper series. So there will be changes for both boards in circuitpython.

@skieast is this OK by you?

