### PR TITLE
"Self-administered" CreationIDs may be used without registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,6 @@ Creation IDs are used to digitally identify unique creations of many forms. They
 
 ## `0xCxxx_xxxx`
 * `0xC3C3_0000` [LILYGO](./creations/lilygo.md)
+
+## `0xFxxx_xxxx`
+* [Fully self-administered CreationIDs created by script](./self-administered.md)

--- a/self-administered.md
+++ b/self-administered.md
@@ -1,0 +1,17 @@
+The Python script `self_administered.py` may be used to generate a fully
+self-administered 64-bit CreatorID:CreationID pair for use in the CreationID
+system, without the requirement to register the ID.
+
+Simply run the script in a terminal and collect your unique ID.
+
+This approach is suggested for individuals making one-off designs. If you plan
+to release multiple designs, you should still allocate a unique CreatorID and
+then allocate CreationIDs as needed in any way you see fit.
+
+It is NOT permitted to generate multiple UUIDs until desirable sub-strings
+appear in the resulting CreationID. If you want to have cute messages made out
+of hex digits in your product's identifier, then allocate a CreatorID.
+
+Statistically, around 1.5 million IDs may be allocated in this fashion before
+the chance of any collision exceeds one-in-a-million. If this is not acceptable
+for your use-case, then allocate a CreatorID.

--- a/self-administered.py
+++ b/self-administered.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import uuid
+
+NS = uuid.uuid5(uuid.NAMESPACE_DNS, "https://github.com/creationid")
+
+def uuid_to_creationid(u):
+    """Perform a non-reversible conversion from UUID to CreationID
+
+    This may be used to generate a fully self-administered 64-bit
+    CreatorID:CreationID pair for use in the CreationID system,
+    without the requirement to register the ID.
+
+    This approach is suggested for people making one-off designs. If you
+    plan to release multiple designs, you should still allocate a unique
+    CreatorID and then allocate CreationIDs as needed in any way you see fit.
+
+    Over 1.5 million IDs may be allocated in this fashion before the chance of
+    any collision exceeds one in a million.
+
+    It is NOT permitted to generate multiple UUIDs until desirable sub-strings
+    appear in the resulting CreationID. If you want to have cute messages made
+    out of hex digits in your product's identifier, then allocate a CreatorID.
+    """
+
+    u = uuid.uuid5(NS, u.hex)
+    h = f"{u.time:015X}"
+    return f"0xF{h[0:3]}_{h[3:7]}:0x{h[7:11]}_{h[11:]}"
+
+def self_administered_creationid():
+    return uuid_to_creationid(uuid.uuid4())
+
+if __name__ == '__main__':
+    print(self_administered_creationid())


### PR DESCRIPTION
If folks doing one-off board definitions have to also create a pull request within `creators.git` it adds even more friction. What if they could simply allocate an ID without registration or coordination?

Note that creators making multiple products are still suggested to register an ID.

As always, if after discussion this turns out to not be sensible or desirable, please feel free to close the PR unmerged.