### PR TITLE
Move ESP32-CAM to AI-Thinker

### DIFF
--- a/creations/ai-thinker.md
+++ b/creations/ai-thinker.md
@@ -3,6 +3,7 @@
 Community Allocated Creation IDs for AI Thinker boards
 
 ## `0x0032_xxxx` - ESP32 dev boards
+*  `0x0032_0001` ESP32-CAM
 
 ## `0x0052_xxxx` - S2 dev boards
 

--- a/creations/espressif.md
+++ b/creations/espressif.md
@@ -3,7 +3,6 @@ Community Allocated Creation IDs for Espressif boards
 
 ## `0x0032_xxxx` - ESP32 dev boards
 *  `0x0032_0001` ESP-EYE
-*  `0x0032_0002` ESP32-CAM
 
 ## `0x0052_xxxx` - S2 dev boards
 


### PR DESCRIPTION
Separate section did not exist before. This is an AI-Thinker board, not directly espressif-made.

The espressif-range creation ID never got used in anything that got merged.
