### PR TITLE
Add LilyGO T18

### DIFF
--- a/creations/lilygo.md
+++ b/creations/lilygo.md
@@ -6,3 +6,6 @@ Community Allocated Creation IDs for LILYGO boards
 *  `0x00C3_0002` [TTGO T-OI-PLUS](https://github.com/Xinyuan-LilyGO/LilyGo-T-OI-PLUS)
 *  `0x00C3_0003` [TTGO T-SIM7000G](https://github.com/Xinyuan-LilyGO/LilyGO-T-SIM7000G)
 *  `0x00C3_0004` [TTGO T-PCIE](https://github.com/Xinyuan-LilyGO/LilyGo-T-PCIE)
+
+## `0x0032_xxxx` - ESP32 boards
+*  `0x0032_0001` [TTGO T18](https://github.com/LilyGO/LILYGO-T-Energy)

--- a/creations/lilygo.md
+++ b/creations/lilygo.md
@@ -4,12 +4,10 @@ Community Allocated Creation IDs for LILYGO boards
 ## `0x0032_xxxx` - ESP32 boards
 *  `0x0032_0001` [T-Watch 2020 (V3)](https://github.com/Xinyuan-LilyGO/TTGO_TWatch_Library)
 *  `0x0032_0002` [TTGO T-DISPLAY ESP32](https://github.com/Xinyuan-LilyGO/TTGO-T-Display)
+*  `0x0032_0003` [TTGO T18](https://github.com/LilyGO/LILYGO-T-Energy)
 
 ## `0x00C3_xxxx` - ESP32-C3 boards
 *  `0x00C3_0001` [TTGO T-01C3](https://github.com/Xinyuan-LilyGO/T-01C3)
 *  `0x00C3_0002` [TTGO T-OI-PLUS](https://github.com/Xinyuan-LilyGO/LilyGo-T-OI-PLUS)
 *  `0x00C3_0003` [TTGO T-SIM7000G](https://github.com/Xinyuan-LilyGO/LilyGO-T-SIM7000G)
 *  `0x00C3_0004` [TTGO T-PCIE](https://github.com/Xinyuan-LilyGO/LilyGo-T-PCIE)
-
-## `0x0032_xxxx` - ESP32 boards
-*  `0x0032_0001` [TTGO T18](https://github.com/LilyGO/LILYGO-T-Energy)


### PR DESCRIPTION
The LilyGO T18 3.0 is also known as LilyGO T-Energy or TTGO T18. Only LilyGO understands their naming structure.