### PR TITLE
01Space and ESP32-C3 board

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Creation IDs are used to digitally identify unique creations of many forms. They
 
 ## `0x00xx_xxxx` - Reserved for future ID subsets
 
+## `0x01xx_xxxx`
+* `0x0101_1ACE` [01 Space](./creations/01space.md)
+
 ## `0x0Dxx_xxxx`
 * `0x0D10_D000` [Hardkernel](./creations/hardkernel.md)
 * `0x0DB6_ED6E` [Debug Edge](https://debug-edge.io)

--- a/creations/01space.md
+++ b/creations/01space.md
@@ -1,0 +1,4 @@
+# 01 Space
+Community Allocated Creation IDs for 01 Space boards
+
+*  `0x00C3_0042` ESP32-C3 0.42 LCD (is an OLED)


### PR DESCRIPTION
This adds a 01Space community-managed creator ID and a creation ID for the "ESP32-C3 0.42 LCD" (which has an OLED, but that's the name).
https://github.com/01Space/ESP32-C3-0.42LCD