### PR TITLE
Add Silabs boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Creation IDs are used to digitally identify unique creations of many forms. They
 * `0x1337_1337` [Mark Olsson (k0d)](https://github.com/k0d)
 * `0x1923_1923` [Deneyap](./creations/deneyap.md)
 * `0x1988_1988` [Wemos](./creations/wemos.md)
+* `0x1996_0000` [Silabs](./creations/silabs.md)
 
 ## `0x6xxx_xxxx`
 * `0x6d44_6576` [MicroDev](https://github.com/microdev1)

--- a/creations/silabs.md
+++ b/creations/silabs.md
@@ -1,0 +1,8 @@
+# silabs-creations
+Community Allocated Creation IDs for Silicon Labs boards
+
+## `0x0024_2601` - xG24 Dev Kit
+
+## `0x0024_2703` - xG24 Explorer Kit
+
+## `0x0024_2704` - SparkFun Thing Plus Matter MGM240P


### PR DESCRIPTION
We would like to add CircuitPython porting to Silabs devkits, but we don't have unique USB VIDs. (https://github.com/adafruit/circuitpython/pull/7833)
We would like to have creation/creator IDs.

I hope this is the right way to do it! Thanks for your help.