### PR TITLE
chore: add heltec & the heltec esp32-s3 "wifi LoRa 32 v3"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Creation IDs are used to digitally identify unique creations of many forms. They
 * `0x1011_1011` [WeAct](./creations/weact.md)
 * `0x1015_1015` [M5Stack](./creations/m5stack.md)
 * `0x1337_1337` [Mark Olsson (k0d)](https://github.com/k0d)
+* `0x148E_173C` [Heltec](./creations/heltec.md)
 * `0x1923_1923` [Deneyap](./creations/deneyap.md)
 * `0x1988_1988` [Wemos](./creations/wemos.md)
 * `0x1996_0000` [Silabs](./creations/silabs.md)

--- a/creations/heltec.md
+++ b/creations/heltec.md
@@ -1,0 +1,5 @@
+# heltec-creations
+Community Allocated Creation IDs for Heltec boards
+
+## `0x0053_xxxx` - ESP32-S3 boards
+*  `0x0053_0001` [WiFi LoRa 32 (V3)](https://heltec.org/project/wifi-lora-32-v3/)


### PR DESCRIPTION
Adds a record for Heltec as a creator (`0x148E_173C`)

Also adds a creation ID of `0x0053_0001` which is having CircuitPython ported to it in https://github.com/adafruit/circuitpython/pull/8583