### PR TITLE
Makerfabs MaTouch ESP32-S3 7" Touch

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Creation IDs are used to digitally identify unique creations of many forms. They
 * `0x1923_1923` [Deneyap](./creations/deneyap.md)
 * `0x1988_1988` [Wemos](./creations/wemos.md)
 * `0x1996_0000` [Silabs](./creations/silabs.md)
+* `0x1A00_0000` [Makerfabs](./creations/makerfabs.md)
 
 ## `0x4xxx_xxxx`
 

--- a/creations/espressif.md
+++ b/creations/espressif.md
@@ -11,6 +11,9 @@ Community Allocated Creation IDs for Espressif boards
 
 ## `0x0053_xxxx` - S3 dev boards
 
+## `0x00A3_xxxx` - S3 dev boards by Makerfabs
+*  `0x00A3_0001` MaTouch ESP32-S3 7" Parallel TFT with Touch (USB Disabled)
+
 ## `0x00C3_xxxx` - C3 dev boards
 *  `0x00C3_0001` ESP32-C3-DevKitM-1
 

--- a/creations/espressif.md
+++ b/creations/espressif.md
@@ -11,9 +11,6 @@ Community Allocated Creation IDs for Espressif boards
 
 ## `0x0053_xxxx` - S3 dev boards
 
-## `0x00A3_xxxx` - S3 dev boards by Makerfabs
-*  `0x00A3_0001` MaTouch ESP32-S3 7" Parallel TFT with Touch (USB Disabled)
-
 ## `0x00C3_xxxx` - C3 dev boards
 *  `0x00C3_0001` ESP32-C3-DevKitM-1
 

--- a/creations/makerfabs.md
+++ b/creations/makerfabs.md
@@ -1,0 +1,14 @@
+# Makerfabs Creations
+
+Community Allocated Creation IDs for [Makerfabs boards](https://www.makerfabs.com/)
+
+Creator ID : 0x1A00_0000
+
+## `0x0032_xxxx` - ESP32 dev boards
+
+## `0x0052_xxxx` - S2 dev boards
+
+## `0x0053_xxxx` - S3 dev boards
+*  `0x0053_81BF` [MaTouch ESP32-S3 TFT with Touch 7" (USB Disabled)](https://www.makerfabs.com/esp32-s3-parallel-tft-with-touch-7-inch.html)
+
+## `0x00C3_xxxx` - C3 dev boards


### PR DESCRIPTION
I'm not sure if the Espressif Community allocation is the correct location for this or if an entry even makes sense, as this is only supporting a custom build option of the Makerfabs tablet that's normally commented out in the mpcofigboard.mk file.