### PR TITLE
Add HEIA-FR / PicoMo Board

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Creation IDs are used to digitally identify unique creations of many forms. They
 
 ## `0x4xxx_xxxx`
 
+* `0x4E1A_1700` [HEIA-FR](creations/heiafr.md)
 * `0x4F58_3097` [Oxocard](creations/oxocard.md)
 
 ## `0x6xxx_xxxx`

--- a/creations/heiafr.md
+++ b/creations/heiafr.md
@@ -1,0 +1,8 @@
+# HEIA-FR Creations
+
+Community Allocated Creation IDs for boards made by the [School of Engineering and Architecture of Fribourg (HEIA-FR)](https://www.heia-fr.ch/en/).
+
+## `0xE095_xxxx` - PicoMo
+
+* `0xE095_0001` [PicoMo V1](https://go.heia-fr.ch/picomo/)
+* `0xE095_0002` [PicoMo V2](https://go.heia-fr.ch/picomo/)


### PR DESCRIPTION
I am porting Circuit Python to the PicoMo, a board made by the School of Engineering and Architecture of Fribourg and based on the RP2040.