### PR TITLE
add unique creation_id for the 4M variant of the T-Display ESP32

### DIFF
--- a/creations/lilygo.md
+++ b/creations/lilygo.md
@@ -3,8 +3,9 @@ Community Allocated Creation IDs for LILYGO boards
 
 ## `0x0032_xxxx` - ESP32 boards
 *  `0x0032_0001` [T-Watch 2020 (V3)](https://github.com/Xinyuan-LilyGO/TTGO_TWatch_Library)
-*  `0x0032_0002` [TTGO T-DISPLAY ESP32](https://github.com/Xinyuan-LilyGO/TTGO-T-Display)
+*  `0x0032_0002` [TTGO T-DISPLAY ESP32 16M](https://github.com/Xinyuan-LilyGO/TTGO-T-Display)
 *  `0x0032_0003` [TTGO T18](https://github.com/LilyGO/LILYGO-T-Energy)
+*  `0x0032_0004` [TTGO T-DISPLAY ESP32 4M](https://github.com/Xinyuan-LilyGO/TTGO-T-Display)
 
 ## `0x00C3_xxxx` - ESP32-C3 boards
 *  `0x00C3_0001` [TTGO T-01C3](https://github.com/Xinyuan-LilyGO/T-01C3)


### PR DESCRIPTION
It is needed for the unique version of CircuitPython for this variant of this board. The "regular" 16M variant already supported by CircuitPython has ID `0x0032_0002` so the smaller 4M flash chip could use `0x0032_0004`.