### PR TITLE
Add VIDI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Creation IDs are used to digitally identify unique creations of many forms. They
 * `0x0101_1ACE` [01 Space](./creations/01space.md)
 
 ## `0x0Dxx_xxxx`
+* `0x0D10_C000` [VIDI](./creations/vidi.md)
 * `0x0D10_D000` [Hardkernel](./creations/hardkernel.md)
 * `0x0DB6_ED6E` [Debug Edge](https://debug-edge.io)
 

--- a/creations/vidi.md
+++ b/creations/vidi.md
@@ -1,0 +1,5 @@
+# vidi-creations
+Community Allocated Creation IDs for VIDI boards
+
+## `0x0032_xxxx` - ESP32 boards
+*  `0x0032_0001` [VIDI X](https://github.com/VIDI-X)


### PR DESCRIPTION
I would like to make new community allocated creation/creator IDs for VIDI X board since it doesn't have unique USB VID and PID. I'm currently in the process of porting it to CircuitPython (https://github.com/adafruit/circuitpython/pull/8798).