### PR TITLE
Add specific ID for ESP32-DevKitC-32E

### DIFF
--- a/creations/espressif.md
+++ b/creations/espressif.md
@@ -5,6 +5,7 @@ Community Allocated Creation IDs for Espressif boards
 *  `0x0032_0001` ESP-EYE
 *  `0x0032_A000` ESP32-LyraT
 *  `0x0032_C000` ESP32-DevKitC
+*  `0x0032_C002` ESP32-DevKitC-32E
 *  `0x0032_C003` ESP32-DevKitC-VE
 
 ## `0x0052_xxxx` - S2 dev boards


### PR DESCRIPTION
So far as I can tell, the ESP32-DevKitC (or more completely, the ESP32-DevKitC-V4) is a dev board that gets populated with a variety of different modules.

ESP32-DevKitC-32E seems to be the part number used for that board when it's populated with the ESP32-WROOM-32E. (4MB flash, no spiram.)

I snuck the ID in ahead of ESP32-DevKitC-VE, which has a WROVER module with 8MB of flash, 8MB spiram.