### PR TITLE
Add LOLIN32 Lite

### DIFF
--- a/creations/wemos.md
+++ b/creations/wemos.md
@@ -5,6 +5,7 @@ Community Allocated Creation IDs for [Wemos boards](https://docs.wemos.cc/en/lat
 Creator ID : 0x1988_1988
 
 ## `0x0032_xxxx` - ESP32 dev boards
+*  `0x0032_0001` [Wemos Lolin32 Lite](https://mischianti.org/esp32-wemos-lolin32-lite-high-resolution-pinout-and-specs)
 
 ## `0x0052_xxxx` - S2 dev boards
 


### PR DESCRIPTION
This is a board that I can't find info about on wemos.cc, but is in common circulation on aliexpress and ebay.
It also has an identical usb-c version that can also be found.

My assumption is that it's an old board that is no longer supported by WeMos.
I couldn't dig up any more info about it.
But considering for how cheap and easily it can be acquired, I will be doing a CircuitPython PR.

The best bit of info about it is:
https://mischianti.org/esp32-wemos-lolin32-lite-high-resolution-pinout-and-specs