### PR TITLE
Add new IDs for boards with CircuitPython just ported to them

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Creation IDs are used to digitally identify unique creations of many forms. They
 * `0x1999_1000` [Sunton](./creations/sunton.md)
 * `0x1A00_0000` [Makerfabs](./creations/makerfabs.md)
 * `0x1BBB_0000` [Waveshare](./creations/waveshare.md)
+* `0x1C33_0000` [Freenove](./creations/freenove.md)
 
 ## `0x4xxx_xxxx`
 

--- a/creations/espressif.md
+++ b/creations/espressif.md
@@ -21,7 +21,3 @@ Community Allocated Creation IDs for Espressif boards
 
 ## `0x0142_xxxx` - H2 dev boards
 *  `0x0142_0001` ESP32-H2-DevKitM-1
-
-## `0x00D0_xxxx` - WROVER-E (ESP32-D0WDQ6) dev boards
-*  `0x00D0-0001` ESP32-WROVER-DEV-CAM
-

--- a/creations/espressif.md
+++ b/creations/espressif.md
@@ -21,3 +21,7 @@ Community Allocated Creation IDs for Espressif boards
 
 ## `0x0142_xxxx` - H2 dev boards
 *  `0x0142_0001` ESP32-H2-DevKitM-1
+
+## `0x00D0_xxxx` - WROVER-E (ESP32-D0WDQ6) dev boards
+*  `0x00D0-0001` ESP32-WROVER-DEV-CAM
+

--- a/creations/freenove.md
+++ b/creations/freenove.md
@@ -1,0 +1,10 @@
+# Freenove
+
+Community Allocated Creation IDs for [Freenove](http://www.freenove.com/)
+
+Creator ID: 0x1C33_0000
+
+## `0x00D0_xxxx` - WROVER-E (ESP32-D0WDQ6) dev boards
+
+*  `0x00D0-0001` [ESP32-WROVER-DEV-CAM](https://store.freenove.com/products/fnk0060)
+

--- a/creations/sunton.md
+++ b/creations/sunton.md
@@ -9,4 +9,13 @@ Creator ID: 0x1999_1000
 *  `0x00AA_0001` [Sunton ESP32-2432S028](https://www.aliexpress.com/item/1005006556177475.html)
 *  `0x00AA_0002` [Sunton ESP32-2424S012](https://www.aliexpress.com/item/1005006300643795.html)
 *  `0x00AA_0004` [Sunton ESP32-8048S070](https://www.aliexpress.com/item/1005005099968475.html)
+*  `0x00AA_0024` [Sunton ESP32-2432S024](https://www.aliexpress.com/item/1005005865107357.html)
+*  `0x00AA_0019` [Sunton ESP32-1732S019](https://www.aliexpress.com/item/1005005059421229.html)
+*  `0x00AA_0024` [Sunton ESP32-2432S024C](https://www.aliexpress.com/item/1005005865107357.html)
+*  `0x00AA_0032` [Sunton ESP32-2432S032](https://www.aliexpress.com/item/1005005138982767.html)
+*  `0x00AA_0035` [Sunton ESP32-3248S035](https://www.aliexpress.com/item/1005005900820162.html)
+*  `0x00AA_0043` [Sunton ESP32-4827S043](https://www.aliexpress.com/item/1005004788147691.html)
+*  `0x00AA_0843` [Sunton ESP32-8048S043](https://www.aliexpress.com/item/1005004788147691.html)
+*  `0x00AA_0050` [Sunton ESP32-8048S050](https://www.aliexpress.com/item/1005004952694042.html)
+*  `0x00AA_0124` [Sunton ESP32-2432S028R](https://www.aliexpress.com/item/1005004502250619.html)
 


### PR DESCRIPTION
Assorted new boards. See (e.g.) https://github.com/adafruit/circuitpython/pull/9233 and https://github.com/adafruit/circuitpython/pull/9238

Note that some of these boards have different hardware -  e.g. ESP32-2432S028R is the restive-touch variant of the ESP32-2432S028C which already exists here as ESP32-2432S028 (  `0x00AA_0001` )