### PR TITLE
added heltec wireless paper device

### DIFF
--- a/creations/heltec.md
+++ b/creations/heltec.md
@@ -6,3 +6,4 @@ Community Allocated Creation IDs for Heltec boards
 
 ## `0x0053_xxxx` - ESP32-S3 boards
 *  `0x0053_0001` [WiFi LoRa 32 (V3)](https://heltec.org/project/wifi-lora-32-v3/)
+*  `0x0053_0002` [Wireless Paper](https://heltec.org/project/wireless-paper/)


### PR DESCRIPTION
To enable new CircuitPython image for the Heltec Wireless Paper LoRa Epaper device.