### PR TITLE
added creation for Elecrow CrowPanel 4.2 EPaper device

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Creation ID allocation is left up to the creator. However, here are some guideli
 * `0x1BBB_0000` [Waveshare](./creations/waveshare.md)
 * `0x1C33_0000` [Freenove](./creations/freenove.md)
 * `0x1C34_0000` [April_Brother](./creations/april_brother.md)
+* `0x1C35_0000` [Elecrow](./creations/elecrow.md)
 
 ## `0x4xxx_xxxx`
 

--- a/creations/elecrow.md
+++ b/creations/elecrow.md
@@ -1,0 +1,5 @@
+# elecrow-creations
+Community Allocated Creation IDs for Elecrow boards
+
+## `0x0000_xxxx` - ESP32-S3 boards
+*  `0x0000_0001` [CrowPanel 4.2 EPaper](https://www.elecrow.com/crowpanel-esp32-4-2-e-paper-hmi-display-with-400-300-resolution-black-white-color-driven-by-spi-interface.html)


### PR DESCRIPTION
Elecrow ESP32S3 N8R8 device with 4.2" Epaper display.  Uses CP310 UART instead of native USB, so creationid is required.