### PR TITLE
Olimex rp2350pc board with VID & PID

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Creation ID allocation is left up to the creator. However, here are some guideli
 
 ## `0x000C_xxxx` - Reserved for USB VID IDs administered by the community
 
+* `0x000C_15BA` [Olimex](./creations/olimex.md)
 * `0x000C_2886` [Seeed Studio](./creations/seeed-studio.md)
 * `0x000C_303A` [Espressif](./creations/espressif.md)
 * `0x000C_303B` [AI Thinker](./creations/ai-thinker.md)

--- a/creations/olimex.md
+++ b/creations/olimex.md
@@ -1,0 +1,7 @@
+# Olimex Creations
+
+Community Allocated Creation IDs for [Olimex](https://www.olimex.com/) boards
+
+## `0x0000_xxxx` -  Olimex boards
+
+* `0x0000_0054` [RP2350pc](https://www.olimex.com/Products/RaspberryPi/PICO/RP2350pc/)


### PR DESCRIPTION
This adds a Creator/Creation ID for the Olimex [RP2350pc](https://www.olimex.com/Products/RaspberryPi/PICO/RP2350pc/) board.

The vendor has confirmed VID=15ba PID=0054 however the USB Host Hub that the board has is wired in parallel with the device USB so the CircuitPython firmware I'm working on will disable the USB device interface requiring the need for the Creator/Creation IDs.